### PR TITLE
enable to set color per poly.

### DIFF
--- a/src/ofxIldaFrame.h
+++ b/src/ofxIldaFrame.h
@@ -3,7 +3,7 @@
 //  ofxIlda
 //
 //  Created by Memo Akten on 09/05/2013.
-//
+//  Updated by Mitsuru Takeuchi on 02/06/2013.
 //
 
 
@@ -13,36 +13,10 @@
 #pragma once
 
 #include "ofMain.h"
+#include "ofxIldaPoly.h"
 #include "ofxIldaPoint.h"
 #include "ofxIldaPolyProcessor.h"
 
-
-namespace ofxIlda {
-	class Poly: public ofPolyline{
-	public:
-		ofFloatColor color;
-		Poly(){clear();};
-		Poly(const vector<ofPoint>& verts){
-			clear();
-			addVertices(verts);
-		};
-		//----------------------------------------------------------
-		static Poly fromRectangle(const ofRectangle& rect) {
-			Poly polyline;
-			polyline.addVertex(rect.getMin());
-			polyline.addVertex(rect.getMaxX(),rect.getMinY());
-			polyline.addVertex(rect.getMax());
-			polyline.addVertex(rect.getMinX(),rect.getMaxY());
-			polyline.close();
-			return polyline;
-		};
-		ofPolyline toOfPolyline(){
-			ofPolyline res = ofPolyline();
-			res.addVertices(getVertices());
-			return res;
-		};
-	};
-};
 
 namespace ofxIlda {
 	
@@ -366,7 +340,6 @@ namespace ofxIlda {
         vector<Poly> origPolys;   // stores the original polys
         vector<Poly> processedPolys;  // stores the processed (smoothed, collapsed, optimized, resampled etc).
         vector<Point> points;   // final points to send
-//        vector<ofFloatColor> processedPolysColor;	// color per poly
         
 		//--------------------------------------------------------------
 		vector<ofPolyline> convertToOfPolyline(vector<Poly> polys){

--- a/src/ofxIldaPoly.h
+++ b/src/ofxIldaPoly.h
@@ -1,0 +1,32 @@
+//
+//  ofxIldaPoly.h
+//  interactivelaser
+//
+//  Created by 武内 満 on 2013/06/02.
+//
+//
+
+#pragma once
+
+namespace ofxIlda {
+    
+	class Poly: public ofPolyline{
+	public:
+		ofFloatColor color;
+		Poly(){clear();};
+		Poly(const vector<ofPoint>& verts){
+			clear();
+			addVertices(verts);
+		};
+		//----------------------------------------------------------
+		static Poly fromRectangle(const ofRectangle& rect) {
+			Poly polyline;
+			polyline.addVertex(rect.getMin());
+			polyline.addVertex(rect.getMaxX(),rect.getMinY());
+			polyline.addVertex(rect.getMax());
+			polyline.addVertex(rect.getMinX(),rect.getMaxY());
+			polyline.close();
+			return polyline;
+		};
+	};
+}


### PR DESCRIPTION
Hi, I'm very happy to use your code!

I'm operating laser in ILDA, and developed inteactive laser in DMX.
So I'm very happy to find this.
But I want to set color per poly, so I add this feature, though I add little code.

I sent my pull request if it is useful for some developers.
I'm happy if you accept my pull request.

If you want to change color, you should set new color to ildaFrame.params.output.color before call addPoly().

sample code:
ofFloatColor color = ofFloatColor(ofRandom(1.0f), ofRandom(1.0f), ofRandom(1.0f), 1);
ildaFrame.params.output.color = color;  // set new color
ildaFrame.addPoly(); // add new poly

Thanks,
Mitsuru
